### PR TITLE
FIX: problem with spaces in process args

### DIFF
--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -3,7 +3,7 @@ namespace :delayed_job do
   def args
     args = ""
     args += "-n #{fetch(:delayed_job_workers)}" unless fetch(:delayed_job_workers).nil?
-    args += "--queues=#{fetch(:delayed_job_queues).join(',')}" unless fetch(:delayed_job_queues).nil?
+    args += " --queues=#{fetch(:delayed_job_queues).join(',')} " unless fetch(:delayed_job_queues).nil?
     args += fetch(:delayed_job_pool).map {|k,v| "--pool=#{k}:#{v}"}.join(' ') unless fetch(:delayed_job_pool).nil?
     args
   end


### PR DESCRIPTION
Arguments where all together (BEFORE):
-n 2--queues=batch_mail,email_stats--pool=batch_mail:2 --pool=email_stats:1 restart
Now:
-n 2 --queues=batch_mail,email_stats --pool=batch_mail:2 --pool=email_stats:1 restart
