### PR TITLE
Fix problem when delayed_job is not executable

### DIFF
--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -48,6 +48,18 @@ namespace :delayed_job do
       end
     end
   end
+  
+  desc 'Fix problem when delayed_job is not executable'
+  task :fix_delayed_job_not_executable do
+    on roles(delayed_job_roles) do
+      within release_path do
+         execute :chmod, '+x', delayed_job_bin
+      end
+    end
+  end
+
+  before :start, :fix_delayed_job_not_executable
+  before :stop, :fix_delayed_job_not_executable
 
   after 'deploy:publishing', 'restart' do
     invoke 'delayed_job:restart'

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -60,6 +60,7 @@ namespace :delayed_job do
 
   before :start, :fix_delayed_job_not_executable
   before :stop, :fix_delayed_job_not_executable
+  before :restart, :fix_delayed_job_not_executable
 
   after 'deploy:publishing', 'restart' do
     invoke 'delayed_job:restart'

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -48,7 +48,9 @@ namespace :delayed_job do
       end
     end
   end
-  
+
+  before :restart, :fix_delayed_job_not_executable
+
   desc 'Fix problem when delayed_job is not executable'
   task :fix_delayed_job_not_executable do
     on roles(delayed_job_roles) do
@@ -57,10 +59,6 @@ namespace :delayed_job do
       end
     end
   end
-
-  before :start, :fix_delayed_job_not_executable
-  before :stop, :fix_delayed_job_not_executable
-  before :restart, :fix_delayed_job_not_executable
 
   after 'deploy:publishing', 'restart' do
     invoke 'delayed_job:restart'


### PR DESCRIPTION
I am deploying on a server with Ubuntu 14.04 - Capistrano 3.3.5.

This gem does not work because of the permitions of the `bin/delayed_job` file in my case

> -rw-rw-r--  1 ubuntu ubuntu  175 Jan 15 18:49 delayed_job

So, using `chmod` fixes this problem.