### PR TITLE
Added the -p Prefix option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Configurable options (copy into deploy.rb), shown here with examples:
 # default value: 1
 set :delayed_job_workers, 2
 
+# String to be prefixed to worker process names
+# This feature allows a prefix name to be placed in front of the process.
+# For example:  reports/delayed_job.0  instead of just delayed_job.0
+set :delayed_job_prefix, :reports               
+
+
 # Delayed_job queue or queues
 # Set the --queue or --queues option to work from a particular queue.
 # default value: nil

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -4,7 +4,7 @@ namespace :delayed_job do
     args = []
     args << "-n #{fetch(:delayed_job_workers)}" unless fetch(:delayed_job_workers).nil?
     args << "--queues=#{fetch(:delayed_job_queues).join(',')}" unless fetch(:delayed_job_queues).nil?
-    args << "-p=#{fetch(:delayed_job_prefix)}" unless fetch(:delayed_job_prefix).nil?
+    args << "-p #{fetch(:delayed_job_prefix)}" unless fetch(:delayed_job_prefix).nil?
     args << fetch(:delayed_job_pools, {}).map {|k,v| "--pool=#{k}:#{v}"}.join(' ') unless fetch(:delayed_job_pools).nil?
     args.join(' ')
   end

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -4,6 +4,7 @@ namespace :delayed_job do
     args = []
     args << "-n #{fetch(:delayed_job_workers)}" unless fetch(:delayed_job_workers).nil?
     args << "--queues=#{fetch(:delayed_job_queues).join(',')}" unless fetch(:delayed_job_queues).nil?
+    args << "-p=#{fetch(:delayed_job_prefix)}" unless fetch(:delayed_job_prefix).nil?
     args << fetch(:delayed_job_pools, {}).map {|k,v| "--pool=#{k}:#{v}"}.join(' ') unless fetch(:delayed_job_pools).nil?
     args.join(' ')
   end


### PR DESCRIPTION
On our production system we use 3 or more delayed job daemons depending on our work load.  In this environment we run the independent delayed_job daemons to process specific queues. We use the -p option to specify a prefix on the process name.  With this we can more easily monitor which delayed_job daemon is busiest (CPU, Memory, ...) due to which queues each is processing.  

Here is an example of our daemons today. 


tuosyst  16731     1 17 Jan28 ?        02:37:34 support/delayed_job.0
tuosyst  16759     1  0 Jan28 ?        00:00:33 support/delayed_job.1
tuosyst  18300     1  0 Jan28 ?        00:02:16 production-realtime/delayed_job.0                                                       
tuosyst  18317     1  0 Jan28 ?        00:02:57 production-realtime/delayed_job.1                                                       
tuosyst  18767     1  6 Jan28 ?        00:53:53 production-batch/delayed_job.=10     


Here is how we start them from the command line today, but would like to move to use your Gem and are upgrading to Capistrano3.

echo "starting delayed_job realtime queues..."
bundle exec script/delayed_job -n2 --queues=emails,update_report_full_stores,update_report_full_catalog,sync_with_authorize_net -p "prod
uction-realtime" start
echo
echo "starting delayed_job background queues..."
bundle exec script/delayed_job -i=10 --queues=on_demand_reports,club_copy_new_year,notices,schedule_report,system_maintenance,audits,bot
s -p "production-batch" start


echo "starting delayed_job support queues..."
bundle exec script/delayed_job --queues=support -n2 -p support start