### PR TITLE
Fix delayed_job:stop

### DIFF
--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -22,7 +22,7 @@ namespace :delayed_job do
     on roles(delayed_job_roles) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :bundle, :exec, delayed_job_bin, :stop
+          execute :bundle, :exec, delayed_job_bin, delayed_job_args, :stop
         end
       end
     end


### PR DESCRIPTION
It's a slightly better version of https://github.com/platanus/capistrano3-delayed-job/pull/11, because of usage of all arguments and not only single number of workers. 

Side note: did you consider using more arguments for DJ in general: https://github.com/collectiveidea/delayed_job/blob/ce88693429188a63793b16daaab67056a4e4e0bf/lib/delayed/command.rb#L27 ?