### PR TITLE
daemons 'stop' command must give the number of workers to correctly s…

### DIFF
--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -22,7 +22,7 @@ namespace :delayed_job do
     on roles(delayed_job_roles) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :bundle, :exec, delayed_job_bin, :stop
+          execute :bundle, :exec, delayed_job_bin, delayed_job_args, :stop
         end
       end
     end


### PR DESCRIPTION
As of the 'daemons' v 1.2.3 gem (which is what delayed_job uses to process 'stop', 'start', etc. commands), failing to specify the number of workers when using the 'stop' or 'status' commands results in the delayed_job pid files not being found, which can cause all kinds of issues in deployment.

This simple change simply sends the delayed_job args (such as "-n 5") along the 'stop' command. It resolves this issue and should be harmless even if 'daemons' changes their ways.