### PR TITLE
add generate-bin-task

### DIFF
--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -51,6 +51,21 @@ namespace :delayed_job do
     end
   end
 
+  desc 'Generate delayed_job binstub'
+  task :generate_bin do
+    on roles(delayed_job_roles) do
+      if fetch(:delayed_job_generate_bin)
+        within release_path do
+          with rails_env: fetch(:rails_env) do
+            execute :bundle, :exec, :rails, :generate, File.basename(delayed_job_bin)
+          end
+        end
+      end
+    end
+  end
+
+  before 'delayed_job:restart', 'delayed_job:generate_bin'
+
   after 'deploy:published', 'restart' do
     invoke 'delayed_job:restart'
   end
@@ -64,5 +79,6 @@ namespace :load do
     set :delayed_job_pools, nil
     set :delayed_job_roles, :app
     set :delayed_job_bin_path, 'bin'
+    set :delayed_job_generate_bin, false
   end
 end


### PR DESCRIPTION
I tried to deploy Rails (4.1.6) application with Capistrano (3.4.0) to my server and failed with error message.

```
 DEBUG [00c5e3ee]       bundler: command not found: bin/delayed_job
Install missing gem executables with `bundle install`
```

It might be same as https://github.com/platanus/capistrano3-delayed-job/issues/6 but I'm not sure.
So fix it in my environment and create this PR. 

Could you merge this if you could reproduce this?
(It would be OK if closed when you couldn't)
