### PR TITLE
Use /tmp for default pid dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ set :delayed_job_bin_path, 'script' # for rails 3.x
 
 ### Set the location of the delayed_job logfile
 set :delayed_log_dir, 'path_to_logfile'
+
+### Set the location of the delayed_job pid file
+set :delayed_job_pid_dir, 'path_to_pid_dir'
 ```
 
 It also adds the following hook
@@ -78,6 +81,17 @@ It also adds the following hook
 after 'deploy:published', 'restart' do
     invoke 'delayed_job:restart'
 end
+```
+
+Following setting is recommended to avoid stop/restart problem.
+See [#16](https://github.com/platanus/capistrano3-delayed-job/issues/16) or [#22](https://github.com/platanus/capistrano3-delayed-job/pull/22) for more detail.
+
+```ruby
+set: linked_dirs, %w(tmp/pids)
+
+# or
+
+set :delayed_job_pid_dir, '/tmp'
 ```
 
 ## Contributing

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -5,6 +5,7 @@ namespace :delayed_job do
     args << "-n #{fetch(:delayed_job_workers)}" unless fetch(:delayed_job_workers).nil?
     args << "--queues=#{fetch(:delayed_job_queues).join(',')}" unless fetch(:delayed_job_queues).nil?
     args << "--prefix=#{fetch(:delayed_job_prefix)}" unless fetch(:delayed_job_prefix).nil?
+    args << "--pid-dir=#{fetch(:delayed_job_pid_dir)}" unless fetch(:delayed_job_pid_dir).nil?
     args << "--log-dir=#{fetch(:delayed_log_dir)}" unless fetch(:delayed_log_dir).nil?
     args << fetch(:delayed_job_pools, {}).map {|k,v| "--pool='#{k}:#{v}'"}.join(' ') unless fetch(:delayed_job_pools).nil?
     args.join(' ')
@@ -64,5 +65,6 @@ namespace :load do
     set :delayed_job_pools, nil
     set :delayed_job_roles, :app
     set :delayed_job_bin_path, 'bin'
+    set :delayed_job_pid_dir, '/tmp'
   end
 end

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -65,6 +65,5 @@ namespace :load do
     set :delayed_job_pools, nil
     set :delayed_job_roles, :app
     set :delayed_job_bin_path, 'bin'
-    set :delayed_job_pid_dir, '/tmp'
   end
 end


### PR DESCRIPTION
I faced same issue as [this one](https://github.com/collectiveidea/delayed_job/issues/623).

It's because old pid file is in old release dir, but restart command searches new release dir.

I fixed this issue by passing `/tmp` dir for `--pid-dir` option. It's working fine for me.