### PR TITLE
Service initializer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,30 @@
+PATH
+  remote: .
+  specs:
+    capistrano3-delayed-job (1.6.0)
+      capistrano (>= 3.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    capistrano (3.4.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (~> 1.3)
+    colorize (0.7.7)
+    i18n (0.7.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.0.1)
+    rake (10.5.0)
+    sshkit (1.7.1)
+      colorize (>= 0.7.0)
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  capistrano3-delayed-job!
+  rake (~> 10.0)

--- a/lib/capistrano/delayed-job.rb
+++ b/lib/capistrano/delayed-job.rb
@@ -1,1 +1,2 @@
+require 'capistrano/dsl/delayed_job_paths'
 load File.expand_path('../tasks/delayed-job.rake', __FILE__)

--- a/lib/capistrano/delayed_job/helpers.rb
+++ b/lib/capistrano/delayed_job/helpers.rb
@@ -1,0 +1,69 @@
+require 'erb'
+
+module Capistrano
+  module DelayedJob
+    module Helpers
+
+      def delayed_job_args
+        args = []
+        args << "-n #{fetch(:delayed_job_workers)}" unless fetch(:delayed_job_workers).nil?
+        args << "--queues=#{fetch(:delayed_job_queues).join(',')}" unless fetch(:delayed_job_queues).nil?
+        args << "--prefix=#{fetch(:delayed_job_prefix)}" unless fetch(:delayed_job_prefix).nil?
+        args << "--pid-dir=#{fetch(:delayed_job_pid_dir)}" unless fetch(:delayed_job_pid_dir).nil?
+        args << "--log-dir=#{fetch(:delayed_log_dir)}" unless fetch(:delayed_log_dir).nil?
+        args << fetch(:delayed_job_pools, {}).map {|k,v| "--pool='#{k}:#{v}'"}.join(' ') unless fetch(:delayed_job_pools).nil?
+        args.join(' ')
+      end
+
+      def bundle_delayed_job
+        SSHKit::Command.new("RAILS_ENV=#{fetch(:stage)}", :bundle, :exec, delayed_job_bin, '$op', delayed_job_args).to_command
+      end
+
+      # renders the ERB template specified by template_name to string. Use the locals variable to pass locals to the
+      # ERB template
+      def template_to_s(template_name, locals = {})
+        config_file = "#{fetch(:templates_path)}/#{template_name}"
+        # if no customized file, proceed with default
+        unless File.exists?(config_file)
+          config_file = File.join(File.dirname(__FILE__), "../../generators/capistrano/delayed_job/templates/#{template_name}")
+        end
+
+        ERB.new(File.read(config_file), nil, '-').result(ERBNamespace.new(locals).get_binding)
+      end
+
+      # renders the ERB template specified by template_name to a StringIO buffer
+      def template(template_name, locals = {})
+        StringIO.new(template_to_s(template_name, locals))
+      end
+
+      def file_exists?(path)
+        test "[ -e #{path} ]"
+      end
+
+      def deploy_user
+        capture :id, '-un'
+      end
+
+      def sudo_upload!(from, to)
+        filename = File.basename(to)
+        to_dir = File.dirname(to)
+        tmp_file = "#{fetch(:tmp_dir)}/#{filename}"
+        upload! from, tmp_file
+        sudo :mv, tmp_file, to_dir
+      end
+
+      # Helper class to pass local variables to an ERB template
+      class ERBNamespace
+        def initialize(hash)
+          hash.each do |key, value|
+            singleton_class.send(:define_method, key) { value }
+          end
+        end
+
+        def get_binding
+          binding
+        end
+      end
+    end
+  end
+end

--- a/lib/capistrano/delayed_job/helpers.rb
+++ b/lib/capistrano/delayed_job/helpers.rb
@@ -40,10 +40,6 @@ module Capistrano
         test "[ -e #{path} ]"
       end
 
-      def deploy_user
-        capture :id, '-un'
-      end
-
       def sudo_upload!(from, to)
         filename = File.basename(to)
         to_dir = File.dirname(to)

--- a/lib/capistrano/dsl/delayed_job_paths.rb
+++ b/lib/capistrano/dsl/delayed_job_paths.rb
@@ -1,0 +1,15 @@
+module Capistrano
+  module DSL
+    module DelayedJobPaths
+
+      def delayed_job_initd_file
+        "/etc/init.d/#{fetch(:delayed_job_service)}"
+      end
+
+      def delayed_job_bin
+        Pathname.new(fetch(:delayed_job_bin_path)).join('delayed_job')
+      end
+
+    end
+  end
+end

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -65,9 +65,10 @@ namespace :delayed_job do
     invoke 'delayed_job:restart'
   end
 
-  after 'deploy:published' do
-    invoke 'delayed_job:setup_initializer'
-  end
+end
+
+namespace :deploy do
+  after :publishing, 'delayed_job:setup_initializer'
 end
 
 namespace :load do

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -49,7 +49,8 @@ namespace :delayed_job do
       execute sudo :rm, '-f', delayed_job_initd_file
       sudo 'update-rc.d', '-f', fetch(:delayed_job_service), 'remove'
     end
-    on roles fetch(:delayed_job_roles) do
+    on roles fetch(:delayed_job_roles) do |server|
+      set :delayed_job_user, server.user
       sudo_upload! template('delayed_job_init.erb'), delayed_job_initd_file
       execute :chmod, '+x', delayed_job_initd_file
       sudo 'update-rc.d', '-f', fetch(:delayed_job_service), 'defaults'

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -45,22 +45,29 @@ namespace :delayed_job do
 
   desc 'Setup Delayed Job initializer'
   task :setup_initializer do
+    puts "*********************************************************"
     on roles(:all) do |host|
+      puts "======================================================="
       execute sudo :rm, '-f', delayed_job_initd_file
       sudo 'update-rc.d', '-f', fetch(:delayed_job_service), 'remove'
     end
     on roles fetch(:delayed_job_roles) do |server|
+      puts "--------------------------------------------------------"
       set :delayed_job_user, server.user
       sudo_upload! template('delayed_job_init.erb'), delayed_job_initd_file
       execute :chmod, '+x', delayed_job_initd_file
       sudo 'update-rc.d', '-f', fetch(:delayed_job_service), 'defaults'
     end
+    puts "*********************************************************"
   end
 
   after 'deploy:published', 'restart' do
     invoke 'delayed_job:restart'
   end
 
+  after 'deploy:published' do
+    invoke 'delayed_job:setup_initializer'
+  end
 end
 
 namespace :load do

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -65,10 +65,10 @@ namespace :delayed_job do
     invoke 'delayed_job:restart'
   end
 
-end
+  after 'deploy:published' do
+    invoke 'delayed_job:setup_initializer'
+  end
 
-namespace :deploy do
-  after :publishing, 'delayed_job:setup_initializer'
 end
 
 namespace :load do

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -65,10 +65,10 @@ namespace :delayed_job do
     invoke 'delayed_job:restart'
   end
 
-  after 'deploy:published' do
-    invoke 'delayed_job:setup_initializer'
-  end
+end
 
+namespace :deploy do
+  after :publishing, 'delayed_job:setup_initializer'
 end
 
 namespace :load do

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -45,28 +45,24 @@ namespace :delayed_job do
 
   desc 'Setup Delayed Job initializer'
   task :setup_initializer do
-    puts "*********************************************************"
     on roles(:all) do |host|
-      puts "======================================================="
       execute sudo :rm, '-f', delayed_job_initd_file
       sudo 'update-rc.d', '-f', fetch(:delayed_job_service), 'remove'
     end
     on roles fetch(:delayed_job_roles) do |server|
-      puts "--------------------------------------------------------"
       set :delayed_job_user, server.user
       sudo_upload! template('delayed_job_init.erb'), delayed_job_initd_file
       execute :chmod, '+x', delayed_job_initd_file
       sudo 'update-rc.d', '-f', fetch(:delayed_job_service), 'defaults'
     end
-    puts "*********************************************************"
   end
 
   after 'deploy:published', 'restart' do
     invoke 'delayed_job:restart'
   end
-  after 'deploy:published' do
-    invoke 'delayed_job:setup_initializer'
-  end
+  # after 'deploy:published' do
+  #   invoke 'delayed_job:setup_initializer'
+  # end
 
 end
 

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -1,22 +1,13 @@
-namespace :delayed_job do
+require 'capistrano/delayed_job/helpers'
+require 'capistrano/dsl/delayed_job_paths'
 
-  def delayed_job_args
-    args = []
-    args << "-n #{fetch(:delayed_job_workers)}" unless fetch(:delayed_job_workers).nil?
-    args << "--queues=#{fetch(:delayed_job_queues).join(',')}" unless fetch(:delayed_job_queues).nil?
-    args << "--prefix=#{fetch(:delayed_job_prefix)}" unless fetch(:delayed_job_prefix).nil?
-    args << "--pid-dir=#{fetch(:delayed_job_pid_dir)}" unless fetch(:delayed_job_pid_dir).nil?
-    args << "--log-dir=#{fetch(:delayed_log_dir)}" unless fetch(:delayed_log_dir).nil?
-    args << fetch(:delayed_job_pools, {}).map {|k,v| "--pool='#{k}:#{v}'"}.join(' ') unless fetch(:delayed_job_pools).nil?
-    args.join(' ')
-  end
+include Capistrano::DelayedJob::Helpers
+include Capistrano::DSL::DelayedJobPaths
+
+namespace :delayed_job do
 
   def delayed_job_roles
     fetch(:delayed_job_roles)
-  end
-
-  def delayed_job_bin
-    Pathname.new(fetch(:delayed_job_bin_path)).join('delayed_job')
   end
 
   desc 'Stop the delayed_job process'
@@ -52,6 +43,19 @@ namespace :delayed_job do
     end
   end
 
+  desc 'Setup Delayed Job initializer'
+  task :setup_initializer do
+    on roles(:all) do |host|
+      execute sudo :rm, '-f', delayed_job_initd_file
+      sudo 'update-rc.d', '-f', fetch(:delayed_job_service), 'remove'
+    end
+    on roles fetch(:delayed_job_roles) do
+      sudo_upload! template('delayed_job_init.erb'), delayed_job_initd_file
+      execute :chmod, '+x', delayed_job_initd_file
+      sudo 'update-rc.d', '-f', fetch(:delayed_job_service), 'defaults'
+    end
+  end
+
   after 'deploy:published', 'restart' do
     invoke 'delayed_job:restart'
   end
@@ -65,5 +69,7 @@ namespace :load do
     set :delayed_job_pools, nil
     set :delayed_job_roles, :app
     set :delayed_job_bin_path, 'bin'
+    set :delayed_job_service, -> { "delayed_job_#{fetch(:application)}_#{fetch(:stage)}" }
+    set :templates_path, 'config/deploy/templates'
   end
 end

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -60,9 +60,10 @@ namespace :delayed_job do
   after 'deploy:published', 'restart' do
     invoke 'delayed_job:restart'
   end
-  # after 'deploy:published' do
-  #   invoke 'delayed_job:setup_initializer'
-  # end
+
+  after 'deploy:published' do
+    invoke 'delayed_job:setup_initializer'
+  end
 
 end
 

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -64,11 +64,10 @@ namespace :delayed_job do
   after 'deploy:published', 'restart' do
     invoke 'delayed_job:restart'
   end
+  after 'deploy:published' do
+    invoke 'delayed_job:setup_initializer'
+  end
 
-end
-
-namespace :deploy do
-  after :publishing, 'delayed_job:setup_initializer'
 end
 
 namespace :load do

--- a/lib/generators/capistrano/delayed_job/USAGE.md
+++ b/lib/generators/capistrano/delayed_job/USAGE.md
@@ -1,0 +1,9 @@
+To create local delayed job configuration files call
+
+    bundle exec rails generate capistrano:delayed_job:config [path]
+
+The default path is "config/deploy/templates". You can override it like so:
+
+    bundle rails generate capistrano:delayed_job:config "config/templates"
+
+If you override templates path, don't forget to set "templates_path" variable in your deploy.rb

--- a/lib/generators/capistrano/delayed_job/config_generator.rb
+++ b/lib/generators/capistrano/delayed_job/config_generator.rb
@@ -1,0 +1,17 @@
+module Capistrano
+  module DelayedJob
+    module Generators
+      class ConfigGenerator < Rails::Generators::Base
+        desc "Create local delayed job initializer configuration files for customization"
+        source_root File.expand_path('../templates', __FILE__)
+        argument :templates_path, type: :string,
+          default: "config/deploy/templates",
+          banner: "path to templates"
+
+        def copy_template
+          copy_file "delayed_job_init.erb", "#{templates_path}/delayed_job_init.erb"
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/capistrano/delayed_job/templates/delayed_job_init.erb
+++ b/lib/generators/capistrano/delayed_job/templates/delayed_job_init.erb
@@ -1,0 +1,44 @@
+#! /bin/sh
+
+### BEGIN INIT INFO
+# Provides:          delayed_job
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:	   $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6 
+# Short-Description: Manage delayed jobs for application <%= fetch(:application) %> , environment <%= fetch(:rails_env) %>
+# Description:       Start, stop, restart delayed jobs for application <%= fetch(:application) %> , environment <%= fetch(:rails_env) %>
+### END INIT INFO
+
+AS_USER=rails
+service="delayed_job"
+
+set -e
+
+interact() {
+    op="$1"
+    echo "Invoking DelayedJob with command '$op'"
+    CMD="cd <%= Pathname.new(fetch(:deploy_to)).join('current') %> && <%= bundle_delayed_job %>"
+
+    if [ "$(id -un)" = "$AS_USER" ]; then
+        eval $CMD
+    else
+        su -c "$CMD" - $AS_USER
+    fi
+}
+
+case "$1" in
+    start|stop)
+        interact "$1"
+        ;;
+    reload|restart|force-reload)
+        interact "stop"
+        sleep 1s
+        interact "start"
+        ;;
+    *)
+        usage
+        ;;
+esac
+
+exit 0

--- a/lib/generators/capistrano/delayed_job/templates/delayed_job_init.erb
+++ b/lib/generators/capistrano/delayed_job/templates/delayed_job_init.erb
@@ -5,12 +5,12 @@
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:	   $remote_fs $syslog
 # Default-Start:     2 3 4 5
-# Default-Stop:      0 1 6 
+# Default-Stop:      0 1 6
 # Short-Description: Manage delayed jobs for application <%= fetch(:application) %> , environment <%= fetch(:rails_env) %>
 # Description:       Start, stop, restart delayed jobs for application <%= fetch(:application) %> , environment <%= fetch(:rails_env) %>
 ### END INIT INFO
 
-AS_USER=rails
+AS_USER=<%= fetch(:delayed_job_user) %> 
 service="delayed_job"
 
 set -e


### PR DESCRIPTION
Create rake task to install a service initializer for delayed jobs on the target server ensuring they are restarted as if it was a fresh deploy on a server reboot.
Each time a deploy happens, we remove this initialize from each server, and reconfigure and push a new one to the roles applicable to have the jobs running on them.  This ensures any change in the number of jobs is reflected in the new file when it is created, as well as the initializer is removed from any host that should no longer have jobs starting on reboot.

