### PR TITLE
pass -m when delayed_job_monitor is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ set :delayed_job_roles, [:app, :background]
 # default value: 'bin'
 # set :delayed_job_bin_path, 'script' # for rails 3.x
 
+# To pass the `-m` option to the delayed_job executable which will cause each
+# worker to be monitored when daemonized.
+# set :delayed_job_monitor, true
+
 ### Set the location of the delayed_job.log logfile
 # default value: "#{Rails.root}/log" or "#{Dir.pwd}/log"
 # set :delayed_log_dir, 'path_to_log_dir'

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -2,6 +2,7 @@ namespace :delayed_job do
 
   def delayed_job_args
     args = []
+    args << "-m" if fetch(:delayed_job_monitor, nil)
     args << "-n #{fetch(:delayed_job_workers)}" unless fetch(:delayed_job_workers).nil?
     args << "--queues=#{fetch(:delayed_job_queues).join(',')}" unless fetch(:delayed_job_queues).nil?
     args << "--prefix=#{fetch(:delayed_job_prefix)}" unless fetch(:delayed_job_prefix).nil?

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -2,7 +2,7 @@ namespace :delayed_job do
 
   def delayed_job_args
     args = []
-    args << "-m" if fetch(:delayed_job_monitor, nil)
+    args << "-m" if fetch(:delayed_job_monitor) # could be set to false
     args << "-n #{fetch(:delayed_job_workers)}" unless fetch(:delayed_job_workers).nil?
     args << "--queues=#{fetch(:delayed_job_queues).join(',')}" unless fetch(:delayed_job_queues).nil?
     args << "--prefix=#{fetch(:delayed_job_prefix)}" unless fetch(:delayed_job_prefix).nil?
@@ -66,5 +66,6 @@ namespace :load do
     set :delayed_job_pools, nil
     set :delayed_job_roles, :app
     set :delayed_job_bin_path, 'bin'
+    set :delayed_job_monitor, nil
   end
 end


### PR DESCRIPTION
With a new variable that defaults to nil, pass along the `-m` option to the delayed_job script which will cause the workers to be monitored.