### PR TITLE
expand examples for delayed_job_pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ set :delayed_job_workers, 2
 # String to be prefixed to worker process names
 # This feature allows a prefix name to be placed in front of the process.
 # For example:  reports/delayed_job.0  instead of just delayed_job.0
-set :delayed_job_prefix, :reports               
+set :delayed_job_prefix, 'reports'
 
 # Delayed_job queue or queues
 # Set the --queue or --queues option to work from a particular queue.
@@ -51,13 +51,36 @@ set :delayed_job_prefix, :reports
 set :delayed_job_queues, ['mailer','tracking']
 
 # Specify different pools
-# You can use this option multiple times to start different numbers of workers for different queues.
+# You can use this option multiple times to start different numbers of workers
+# for different queues.
+# NOTE: When using delayed_job_pools, the settings for delayed_job_workers and
+# delayed_job_queues are ignored.
 # default value: nil
-set :delayed_job_pools, {
-    :mailer => 2,
-    :tracking => 1,
-    :* => 2
-}
+#
+# Single pool of 3 workers looking at all queues: (when alone, '*' is a
+# special case meaning any queue)
+# set :delayed_job_pools, { '*' => 3 }
+# set :delayed_job_pools, { '' => 3 }
+# set :delayed_job_pools, { nil => 3 }
+#
+# Several queues, some with their own dedicated pools: (symbol keys will be
+# converted to strings)
+# set :delayed_job_pools, {
+#     :mailer => 2,    # 2 workers looking only at the 'mailer' queue
+#     :tracking => 1,  # 1 worker exclusively for the 'tracking' queue
+#     :* => 2          # 2 on any queue (including 'mailer' and 'tracking')
+# }
+#
+# Several workers each handling one or more queues:
+# set :delayed_job_pools, {
+#     'high_priority' => 1,                # one just for the important stuff
+#     'high_priority,*' => 1,              # never blocked by low_priority jobs
+#     'high_priority,*,low_priority' => 1, # works on whatever is available
+#     '*,low_priority' => 1,  # high_priority doesn't starve the little guys
+#   }
+# Identification is assigned in order 0..3.
+# Note that the '*' in this case is actually a queue with that name and does
+# not mean any queue as it is not used alone, but alongside other queues.
 
 # Set the roles where the delayed_job process should be started
 # default value: :app
@@ -65,14 +88,16 @@ set :delayed_job_roles, [:app, :background]
 
 # Set the location of the delayed_job executable
 # Can be relative to the release_path or absolute
-# default value 'bin'
-set :delayed_job_bin_path, 'script' # for rails 3.x
+# default value: 'bin'
+# set :delayed_job_bin_path, 'script' # for rails 3.x
 
-### Set the location of the delayed_job logfile
-set :delayed_log_dir, 'path_to_logfile'
+### Set the location of the delayed_job.log logfile
+# default value: "#{Rails.root}/log" or "#{Dir.pwd}/log"
+# set :delayed_log_dir, 'path_to_log_dir'
 
-### Set the location of the delayed_job pid file
-set :delayed_job_pid_dir, 'path_to_pid_dir'
+### Set the location of the delayed_job pid file(s)
+# default value: "#{Rails.root}/tmp/pids" or "#{Dir.pwd}/tmp/pids"
+# set :delayed_job_pid_dir, 'path_to_pid_dir'
 ```
 
 It also adds the following hook
@@ -113,4 +138,3 @@ capistrano3-delayed-job is maintained by [platanus](http://platan.us).
 ## License
 
 Guides is © 2014 platanus, spa. It is free software and may be redistributed under the terms specified in the LICENSE file.
-


### PR DESCRIPTION
As I went looking to make a code change to allow multiple, named pools of workers handling different subsets of queues, I found that such configuration could already be specified with the existing code, but the example for delayed_job_pools gave no clue as to how that could be done.