### PR TITLE
Add delayed job status task

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ require 'capistrano/delayed-job'
 You will get the following tasks
 
 ```ruby
-cap delayed_job:start                    # Start delayed_job service
-cap delayed_job:stop                     # Stop delayed_job service
-cap delayed_job:restart                  # Restart delayed_job service
+cap delayed_job:restart  # Restart the delayed_job process
+cap delayed_job:start    # Start the delayed_job process
+cap delayed_job:status   # Status of the delayed_job process
+cap delayed_job:stop     # Stop the delayed_job process
 ```
 
 Configurable options (copy into deploy.rb), shown here with examples:

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -42,6 +42,17 @@ namespace :delayed_job do
     end
   end
 
+  desc 'Status of the delayed_job process'
+  task :status do
+    on roles(delayed_job_roles) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :bundle, :exec, delayed_job_bin, delayed_job_args, :status
+        end
+      end
+    end
+  end
+
   desc 'Restart the delayed_job process'
   task :restart do
     on roles(delayed_job_roles) do

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -47,7 +47,9 @@ namespace :delayed_job do
     on roles(delayed_job_roles) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :bundle, :exec, delayed_job_bin, delayed_job_args, :status
+          capture( :bundle, :exec, delayed_job_bin, delayed_job_args, :status ).each_line do |line|
+            info line
+          end
         end
       end
     end


### PR DESCRIPTION
Saw some other forks that also claimed to do this, but no PR?

In any case, the output from `capture` is sent to `info` by lines so that it give meaningful output even when using [airbrussh](https://github.com/mattbrictson/airbrussh) (as I am).