### PR TITLE
Fix compatibility with Capistrano 3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ set :delayed_job_roles, [:app, :background]
 It also adds the following hook
 
 ```ruby
-after 'deploy:published', 'restart' do
+after 'deploy:published', 'delayed_job:restart' do
     invoke 'delayed_job:restart'
 end
 ```

--- a/lib/capistrano/tasks/delayed-job.rake
+++ b/lib/capistrano/tasks/delayed-job.rake
@@ -66,7 +66,7 @@ namespace :delayed_job do
     end
   end
 
-  after 'deploy:published', 'restart' do
+  after 'deploy:published', 'delayed_job:restart' do
     invoke 'delayed_job:restart'
   end
 


### PR DESCRIPTION
Because of the missing namespace the hook was not executed after upgrading to Capistrano 3.5.0

See capistrano/capistrano#1652